### PR TITLE
Endpoint and resolver address in tests

### DIFF
--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -8,35 +8,29 @@ import (
 	config "github.com/rnsdomains/rns-go-lib/config"
 )
 
-type ResolveAddressTestCases struct {
+type ResolveRNSTestCases struct {
 	networkNodeAddress string
 	resolverAddress    string
 	domainToResolve    string
 	expectedAddress    common.Address
-}
-
-type ResolveContentTestCase struct {
-	networkNodeAddress string
-	resolverAddress    string
-	domainToResolve    string
 	expectedHash       common.Hash
 }
 
 func TestResolveDomainAddress(t *testing.T) {
 	// if any of these fail, verify their correctness in RNS manager and update if necessary
-	testCases := []ResolveAddressTestCases{
-		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "alecavallero.rsk", common.HexToAddress("0xa78c937844b27bec024f042dcbe5b85d2b7344f6")},
-		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "martin.rsk", common.HexToAddress("0xfb530616391cb526387bad651594bc21a77d3dfe")},
-		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "pedro.rsk", common.HexToAddress("0x0164be16739135950c2fea0e75c98123f7ca06cf")},
-		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "ny.consensus.rsk", common.HexToAddress("0xdbb8fd0a18fd84ba548a7e00e86465fe3de869f8")},
-		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "marcelosdomain.rsk", common.HexToAddress("0xfF33bC3B7324C2A808A9D415935f8D991E6C406c")},
-		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "unregistered.rsk", common.HexToAddress("0x0000000000000000000000000000000000000000")},
-		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "invalidom.ain", common.HexToAddress("0x0000000000000000000000000000000000000000")},
+	testCases := []ResolveRNSTestCases{
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "alecavallero.rsk", common.HexToAddress("0xa78c937844b27bec024f042dcbe5b85d2b7344f6"), common.Hash{}},
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "martin.rsk", common.HexToAddress("0xfb530616391cb526387bad651594bc21a77d3dfe"), common.Hash{}},
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "pedro.rsk", common.HexToAddress("0x0164be16739135950c2fea0e75c98123f7ca06cf"), common.Hash{}},
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "ny.consensus.rsk", common.HexToAddress("0xdbb8fd0a18fd84ba548a7e00e86465fe3de869f8"), common.Hash{}},
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "marcelosdomain.rsk", common.HexToAddress("0xfF33bC3B7324C2A808A9D415935f8D991E6C406c"), common.Hash{}},
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "unregistered.rsk", common.HexToAddress("0x0000000000000000000000000000000000000000"), common.Hash{}},
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "invalidom.ain", common.HexToAddress("0x0000000000000000000000000000000000000000"), common.Hash{}},
 	}
 	resolveDomainAddressTestCases(t, testCases)
 }
 
-func resolveDomainAddressTestCases(t *testing.T, testCases []ResolveAddressTestCases) {
+func resolveDomainAddressTestCases(t *testing.T, testCases []ResolveRNSTestCases) {
 	var emptyAddress common.Address
 	for _, testCase := range testCases {
 		t.Run(fmt.Sprint(testCase.domainToResolve), func(t *testing.T) {
@@ -59,17 +53,17 @@ func resolveDomainAddressTestCases(t *testing.T, testCases []ResolveAddressTestC
 }
 func TestResolveDomainContent(t *testing.T) {
 	// if any of these fail, verify their correctness in RNS manager and update if necessary
-	testCases := []ResolveContentTestCase{
-		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "vojtech.rsk", common.HexToHash("0x625f47dcda50ad052c620d2f63bd8ffc14f1184833b2f11876e21dc02df393f7")},
-		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "marcelosdomain.rsk", common.HexToHash("0x88ced8ba8e9396672840b47e332b33d6679d9962d80cf340d3cf615db23d4e07")},
-		{"https://public-node.testnet.rsk.co", "0x404308f2a2eec2cdc3cb53d7d295af11c903414e", "santiagosdomain.rsk", common.HexToHash("0x88ced8ba8e9396672840b47e332b33d6679d9962d80cf340d3cf615db23d4e07")},
-		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "unregistered.rsk", common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000")},
-		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "invalidom.ain", common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000")},
+	testCases := []ResolveRNSTestCases{
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "vojtech.rsk", common.Address{}, common.HexToHash("0x625f47dcda50ad052c620d2f63bd8ffc14f1184833b2f11876e21dc02df393f7")},
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "marcelosdomain.rsk", common.Address{}, common.HexToHash("0x88ced8ba8e9396672840b47e332b33d6679d9962d80cf340d3cf615db23d4e07")},
+		{"https://public-node.testnet.rsk.co", "0x404308f2a2eec2cdc3cb53d7d295af11c903414e", "santiagosdomain.rsk", common.Address{}, common.HexToHash("0x88ced8ba8e9396672840b47e332b33d6679d9962d80cf340d3cf615db23d4e07")},
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "unregistered.rsk", common.Address{}, common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000")},
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "invalidom.ain", common.Address{}, common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000")},
 	}
 	resolveDomainContentTestCases(t, testCases)
 }
 
-func resolveDomainContentTestCases(t *testing.T, testCases []ResolveContentTestCase) {
+func resolveDomainContentTestCases(t *testing.T, testCases []ResolveRNSTestCases) {
 	var emptyContent [32]byte
 	for _, testCase := range testCases {
 		t.Run(fmt.Sprint(testCase.domainToResolve), func(t *testing.T) {

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -9,10 +9,10 @@ import (
 )
 
 type ResolveAddressTestCases struct {
-	networkAddress  string
-	resolverAddress string
-	domainToResolve string
-	expectedAddress common.Address
+	networkNodeAddress string
+	resolverAddress    string
+	domainToResolve    string
+	expectedAddress    common.Address
 }
 
 type ResolveContentTestCase struct {
@@ -40,7 +40,7 @@ func resolveDomainAddressTestCases(t *testing.T, testCases []ResolveAddressTestC
 	var emptyAddress common.Address
 	for _, testCase := range testCases {
 		t.Run(fmt.Sprint(testCase.domainToResolve), func(t *testing.T) {
-			config.SetConfiguration(testCase.networkAddress, testCase.resolverAddress)
+			config.SetConfiguration(testCase.networkNodeAddress, testCase.resolverAddress)
 			resolvedAddress, resolutionError := ResolveDomainAddress(testCase.domainToResolve)
 			if testCase.expectedAddress != resolvedAddress {
 				t.Errorf("Expected address %v and got %v.", testCase.expectedAddress, resolvedAddress)
@@ -73,7 +73,7 @@ func resolveDomainContentTestCases(t *testing.T, testCases []ResolveContentTestC
 	var emptyContent [32]byte
 	for _, testCase := range testCases {
 		t.Run(fmt.Sprint(testCase.domainToResolve), func(t *testing.T) {
-			config.SetConfiguration(testCase.networkAddress, testCase.resolverAddress)
+			config.SetConfiguration(testCase.networkNodeAddress, testCase.resolverAddress)
 			resolvedContent, resolutionError := ResolveDomainContent(testCase.domainToResolve)
 			if testCase.expectedHash != resolvedContent {
 				t.Errorf("Expected hash %v and got %v.", testCase.expectedHash, resolvedContent)

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -5,14 +5,19 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	config "github.com/rnsdomains/rns-go-lib/config"
 )
 
 type ResolveAddressTestCases struct {
+	networkAddress  string
+	resolverAddress string
 	domainToResolve string
 	expectedAddress common.Address
 }
 
 type ResolveContentTestCase struct {
+	networkAddress  string
+	resolverAddress string
 	domainToResolve string
 	expectedHash    common.Hash
 }
@@ -20,13 +25,13 @@ type ResolveContentTestCase struct {
 func TestResolveDomainAddress(t *testing.T) {
 	// if any of these fail, verify their correctness in RNS manager and update if necessary
 	testCases := []ResolveAddressTestCases{
-		{"alecavallero.rsk", common.HexToAddress("0xa78c937844b27bec024f042dcbe5b85d2b7344f6")},
-		{"martin.rsk", common.HexToAddress("0xfb530616391cb526387bad651594bc21a77d3dfe")},
-		{"pedro.rsk", common.HexToAddress("0x0164be16739135950c2fea0e75c98123f7ca06cf")},
-		{"ny.consensus.rsk", common.HexToAddress("0xdbb8fd0a18fd84ba548a7e00e86465fe3de869f8")},
-		{"marcelosdomain.rsk", common.HexToAddress("0xfF33bC3B7324C2A808A9D415935f8D991E6C406c")},
-		{"unregistered.rsk", common.HexToAddress("0x0000000000000000000000000000000000000000")},
-		{"invalidom.ain", common.HexToAddress("0x0000000000000000000000000000000000000000")},
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "alecavallero.rsk", common.HexToAddress("0xa78c937844b27bec024f042dcbe5b85d2b7344f6")},
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "martin.rsk", common.HexToAddress("0xfb530616391cb526387bad651594bc21a77d3dfe")},
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "pedro.rsk", common.HexToAddress("0x0164be16739135950c2fea0e75c98123f7ca06cf")},
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "ny.consensus.rsk", common.HexToAddress("0xdbb8fd0a18fd84ba548a7e00e86465fe3de869f8")},
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "marcelosdomain.rsk", common.HexToAddress("0xfF33bC3B7324C2A808A9D415935f8D991E6C406c")},
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "unregistered.rsk", common.HexToAddress("0x0000000000000000000000000000000000000000")},
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "invalidom.ain", common.HexToAddress("0x0000000000000000000000000000000000000000")},
 	}
 	resolveDomainAddressTestCases(t, testCases)
 }
@@ -35,6 +40,7 @@ func resolveDomainAddressTestCases(t *testing.T, testCases []ResolveAddressTestC
 	var emptyAddress common.Address
 	for _, testCase := range testCases {
 		t.Run(fmt.Sprint(testCase.domainToResolve), func(t *testing.T) {
+			config.SetConfiguration(testCase.networkAddress, testCase.resolverAddress)
 			resolvedAddress, resolutionError := ResolveDomainAddress(testCase.domainToResolve)
 			if testCase.expectedAddress != resolvedAddress {
 				t.Errorf("Expected address %v and got %v.", testCase.expectedAddress, resolvedAddress)
@@ -54,10 +60,11 @@ func resolveDomainAddressTestCases(t *testing.T, testCases []ResolveAddressTestC
 func TestResolveDomainContent(t *testing.T) {
 	// if any of these fail, verify their correctness in RNS manager and update if necessary
 	testCases := []ResolveContentTestCase{
-		{"vojtech.rsk", common.HexToHash("0x625f47dcda50ad052c620d2f63bd8ffc14f1184833b2f11876e21dc02df393f7")},
-		{"marcelosdomain.rsk", common.HexToHash("0x88ced8ba8e9396672840b47e332b33d6679d9962d80cf340d3cf615db23d4e07")},
-		{"unregistered.rsk", common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000")},
-		{"invalidom.ain", common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000")},
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "vojtech.rsk", common.HexToHash("0x625f47dcda50ad052c620d2f63bd8ffc14f1184833b2f11876e21dc02df393f7")},
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "marcelosdomain.rsk", common.HexToHash("0x88ced8ba8e9396672840b47e332b33d6679d9962d80cf340d3cf615db23d4e07")},
+		{"https://public-node.testnet.rsk.co", "0x404308f2a2eec2cdc3cb53d7d295af11c903414e", "santiagosdomain.rsk", common.HexToHash("0x88ced8ba8e9396672840b47e332b33d6679d9962d80cf340d3cf615db23d4e07")},
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "unregistered.rsk", common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000")},
+		{"https://public-node.rsk.co", "0x99a12be4C89CbF6CFD11d1F2c029904a7B644368", "invalidom.ain", common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000")},
 	}
 	resolveDomainContentTestCases(t, testCases)
 }
@@ -66,6 +73,7 @@ func resolveDomainContentTestCases(t *testing.T, testCases []ResolveContentTestC
 	var emptyContent [32]byte
 	for _, testCase := range testCases {
 		t.Run(fmt.Sprint(testCase.domainToResolve), func(t *testing.T) {
+			config.SetConfiguration(testCase.networkAddress, testCase.resolverAddress)
 			resolvedContent, resolutionError := ResolveDomainContent(testCase.domainToResolve)
 			if testCase.expectedHash != resolvedContent {
 				t.Errorf("Expected hash %v and got %v.", testCase.expectedHash, resolvedContent)

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -16,10 +16,10 @@ type ResolveAddressTestCases struct {
 }
 
 type ResolveContentTestCase struct {
-	networkAddress  string
-	resolverAddress string
-	domainToResolve string
-	expectedHash    common.Hash
+	networkNodeAddress string
+	resolverAddress    string
+	domainToResolve    string
+	expectedHash       common.Hash
 }
 
 func TestResolveDomainAddress(t *testing.T) {


### PR DESCRIPTION
Changes the tests to include endpoint of the blockchain and the resolver address.

For example some integration test against mainnet and other vs testnet.